### PR TITLE
Fix broken GitHub repo section

### DIFF
--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -179,15 +179,15 @@ export default function Page() {
         <div className="mt-10 grid w-full grid-cols-1 items-start justify-center gap-4 md:grid-cols-2 lg:grid-cols-2 2xl:grid-cols-3">
           {repositories?.map((repository, index) => (
             <motion.div
-              layoutId={index}
-              key={index}
+              layoutId={index + 1}
+              key={index + 1}
               className="flex h-full w-full cursor-pointer flex-col items-start justify-start gap-4 rounded-lg bg-neutral-800 p-4 shadow-lg"
               onClick={() => {
-                setSelectedRepoId(index);
+                setSelectedRepoId(index + 1);
                 handleRepoClick(repository?.name);
               }}
               style={
-                selectedRepoId === index
+                selectedRepoId === index + 1
                   ? {
                       opacity: 0,
                       transition: "all 0.3s ease-in-out",
@@ -250,7 +250,7 @@ export default function Page() {
           <AnimatePresence>
             {selectedRepoId !== null &&
               selectedRepoId &&
-              repositories[selectedRepoId] && (
+              repositories[selectedRepoId - 1] && (
                 <>
                   <motion.div
                     layoutId={selectedRepoId}

--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -258,16 +258,16 @@ export default function Page() {
                     onClick={() => setSelectedRepoId(null)}
                   >
                     <motion.div
-                      className="max-h-auto z-[102] flex h-auto w-auto min-w-[60%] cursor-auto flex-col items-start justify-start rounded-lg bg-neutral-800 p-4 shadow-lg"
+                      className="max-h-auto z-[102] flex h-auto min-w-[60%] w-auto cursor-auto flex-col items-start justify-start rounded-lg bg-neutral-800 p-4 shadow-lg"
                       onClick={(e) => e.stopPropagation()}
                     >
                       <div className="flex w-full flex-row items-start justify-between">
                         <div className="flex w-2/3 flex-row items-center justify-start gap-2">
                           <Image
                             src={
-                              repositories[selectedRepoId]?.owner?.avatar_url
+                              repositories[selectedRepoId - 1]?.owner?.avatar_url
                             }
-                            alt={repositories[selectedRepoId]?.owner?.login}
+                            alt={repositories[selectedRepoId - 1]?.owner?.login}
                             width={48}
                             height={48}
                             className="h-12 w-12 rounded-lg bg-neutral-900 shadow-lg"
@@ -275,11 +275,11 @@ export default function Page() {
                           />
                           <div className="flex w-full flex-col items-start justify-start">
                             <p className="text-lg font-bold">
-                              {repositories[selectedRepoId]?.owner?.login}
+                              {repositories[selectedRepoId - 1]?.owner?.login}
                             </p>
                             <p className="text-sm text-gray-400">
                               {new Date(
-                                repositories[selectedRepoId]?.updated_at,
+                                repositories[selectedRepoId - 1]?.updated_at,
                               ).toDateString()}
                             </p>
                           </div>
@@ -301,7 +301,7 @@ export default function Page() {
                               />
                             </svg>
                             <h1 className="text-md font-bold">
-                              {repositories[selectedRepoId]?.stargazers_count}
+                              {repositories[selectedRepoId - 1]?.stargazers_count}
                             </h1>
                           </div>
                           <div className="flex flex-row items-center justify-start gap-1">
@@ -369,16 +369,16 @@ export default function Page() {
                         </div>
                       </div>
                       <h3 className="mt-2 text-2xl font-bold">
-                        {repositories[selectedRepoId]?.name}
+                        {repositories[selectedRepoId - 1]?.name}
                       </h3>
                       <p className="text-left text-lg text-white/80">
-                        {repositories[selectedRepoId]?.description
-                          ? repositories[selectedRepoId].description.length > 60
-                            ? repositories[selectedRepoId].description.slice(
+                        {repositories[selectedRepoId - 1]?.description
+                          ? repositories[selectedRepoId - 1].description.length > 60
+                            ? repositories[selectedRepoId - 1].description.slice(
                                 0,
                                 60,
                               ) + "..."
-                            : repositories[selectedRepoId].description ||
+                            : repositories[selectedRepoId - 1].description ||
                               "No description provided."
                           : "No description provided."}
                       </p>
@@ -401,7 +401,7 @@ export default function Page() {
                                         className="flex w-full cursor-pointer flex-row items-center justify-between gap-2 border-b border-neutral-700 p-2 hover:bg-neutral-700"
                                         onClick={() => {
                                           router.push(
-                                            `https://github.com/${repositories[selectedRepoId]?.owner?.login}/${repositories[selectedRepoId]?.name}/tree/main/${file?.path}`,
+                                            `https://github.com/${repositories[selectedRepoId - 1]?.owner?.login}/${repositories[selectedRepoId - 1]?.name}/tree/main/${file?.path}`,
                                           );
                                         }}
                                       >
@@ -460,7 +460,7 @@ export default function Page() {
                                 className="flex w-full cursor-pointer flex-row items-center justify-center gap-2 border-b border-neutral-700 p-2 hover:bg-neutral-700"
                                 onClick={() =>
                                   router.push(
-                                    `https://github.com/${repositories[selectedRepoId]?.owner?.login}/${repositories[selectedRepoId]?.name}`,
+                                    `https://github.com/${repositories[selectedRepoId - 1]?.owner?.login}/${repositories[selectedRepoId - 1]?.name}`,
                                   )
                                 }
                               >


### PR DESCRIPTION
Related to #7

Fix the broken GitHub Repo section on the projects page.

* **Update `handleRepoClick` function**
  - Fetch the repository files without causing the blurring effect.
* **Update `AnimatePresence` component**
  - Prevent the blurring effect when a repository is clicked.
* **Address sorting problem with `framer-motion`**
  - Ensure the file tree is displayed correctly.
* **Modify layoutId and key for repositories**
  - Increment index by 1 to avoid conflicts.
* **Update selectedRepoId logic**
  - Adjust selectedRepoId to match the new index logic.